### PR TITLE
Add markdown in comment output

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Comments.ui.config({
     limit: 20, // default 10
     loadMoreCount: 20, // default 20
     template: 'bootstrap', // default 'semantic-ui'
-    defaultAvatar: 'my/defaultavatarimage.png' // default 'http://s3.amazonaws.com/37assets/svn/765-default-avatar.png'
+    defaultAvatar: 'my/defaultavatarimage.png' // default 'http://s3.amazonaws.com/37assets/svn/765-default-avatar.png',
+    markdown: true // default false
 });
 ```

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Comments.ui.config({
     limit: 20, // default 10
     loadMoreCount: 20, // default 20
     template: 'bootstrap', // default 'semantic-ui'
-    defaultAvatar: 'my/defaultavatarimage.png' // default 'http://s3.amazonaws.com/37assets/svn/765-default-avatar.png',
+    defaultAvatar: 'my/defaultavatarimage.png', // default 'http://s3.amazonaws.com/37assets/svn/765-default-avatar.png'
     markdown: true // default false
 });
 ```

--- a/lib/templates.html
+++ b/lib/templates.html
@@ -76,7 +76,9 @@
                     <span class="date">{{createdAgo}}</span>
                 </div>
                 <div class="text comment-content" data-id="{{commentId}}">
+                    {{#markdown}}
                     {{content}}
+                    {{/markdown}}
                 </div>
                 {{#if image}}
                     <div class="content-image">
@@ -124,7 +126,7 @@
             <div class="media-body comment">
                 <h4 class="media-heading">{{user.displayName}} <small>{{createdAgo}}</small></h4>
                 <div class="content">
-                    <p class="comment-content" data-id="{{commentId}}">{{content}}</p>
+                    <p class="comment-content" data-id="{{commentId}}">{{#markdown}}{{content}}{{/markdown}}</p>
 
                     <div class="actions btn-group btn-group-xs">
                         <div class="btn {{#if hasLiked}}btn-primary{{else}}btn-default{{/if}} like-action" aria-label="Left Align">
@@ -177,7 +179,7 @@
             </div>
 
             <div class="item item-body comment">
-                <p class="comment-content" data-id="{{commentId}}">{{content}}</p>
+                <p class="comment-content" data-id="{{commentId}}">{{#markdown}}{{content}}{{/markdown}}</p>
 
                 <div class="actions">
                     <div class="button-bar">

--- a/lib/templates.html
+++ b/lib/templates.html
@@ -76,9 +76,13 @@
                     <span class="date">{{createdAgo}}</span>
                 </div>
                 <div class="text comment-content" data-id="{{commentId}}">
-                    {{#markdown}}
-                    {{content}}
-                    {{/markdown}}
+                    {{#if isMarkdown}}
+                        {{#markdown}}
+                            {{content}}
+                        {{/markdown}}
+                    {{else}}
+                        {{content}}
+                    {{/if}}
                 </div>
                 {{#if image}}
                     <div class="content-image">
@@ -126,7 +130,15 @@
             <div class="media-body comment">
                 <h4 class="media-heading">{{user.displayName}} <small>{{createdAgo}}</small></h4>
                 <div class="content">
-                    <p class="comment-content" data-id="{{commentId}}">{{#markdown}}{{content}}{{/markdown}}</p>
+                    <p class="comment-content" data-id="{{commentId}}">
+                        {{#if isMarkdown}}
+                            {{#markdown}}
+                                {{content}}
+                            {{/markdown}}
+                        {{else}}
+                            {{content}}
+                        {{/if}}
+                    </p>
 
                     <div class="actions btn-group btn-group-xs">
                         <div class="btn {{#if hasLiked}}btn-primary{{else}}btn-default{{/if}} like-action" aria-label="Left Align">
@@ -179,7 +191,15 @@
             </div>
 
             <div class="item item-body comment">
-                <p class="comment-content" data-id="{{commentId}}">{{#markdown}}{{content}}{{/markdown}}</p>
+                <p class="comment-content" data-id="{{commentId}}">
+                    {{#if isMarkdown}}
+                        {{#markdown}}
+                            {{content}}
+                        {{/markdown}}
+                    {{else}}
+                        {{content}}
+                    {{/if}}
+                </p>
 
                 <div class="actions">
                     <div class="button-bar">

--- a/lib/templates/commentsBox.js
+++ b/lib/templates/commentsBox.js
@@ -20,6 +20,9 @@
       },
       commentId: function () {
         return this._id || this.replyId;
+      },
+      isMarkdown: function () {
+        return Comments.ui.config().markdown;
       }
     },
     handles = {};

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -11,7 +11,8 @@ Comments.ui = (function () {
     limit: 10,
     loadMoreCount: 20,
     template: 'semantic-ui',
-    defaultAvatar:'http://s3.amazonaws.com/37assets/svn/765-default-avatar.png'
+    defaultAvatar:'http://s3.amazonaws.com/37assets/svn/765-default-avatar.png',
+    markdown: false
   };
 
   Meteor.startup(function () {

--- a/package.js
+++ b/package.js
@@ -12,7 +12,7 @@ Package.onUse(function(api) {
   // Meteor Core Dependencies
   api.use(['accounts-password@1.0.1'], { weak: true });
   api.use([
-    'underscore', 'mongo-livedata', 'templating', 'jquery', 'check', 'less@2.5.0_2', 'tracker', 'check', 'session', 'random'
+    'underscore', 'mongo-livedata', 'templating', 'jquery', 'check', 'less@2.5.0_2', 'tracker', 'check', 'session', 'random', 'markdown'
   ]);
 
   // Atmosphere Package Dependencies


### PR DESCRIPTION
Firstly, thanks for this package, saved us a ton of time. :+1: 

Added `{{#markdown}}` around the `{{content}}` output of the comments.

This adds simple newline support to existing comments, and makes the output a little more readable I think. It's also pretty safe, as markdown doesn't allow XSS injections or anything of that nature (as far as I know!).

I've tested the bootstrap version and it renders properly for me. Can't promise there's no bugs in the other two templates, but the changes were pretty small. :-)