### PR TITLE
Remove whitespace inside `{{#markdown}}`. fix #48

### DIFF
--- a/lib/templates.html
+++ b/lib/templates.html
@@ -77,9 +77,7 @@
                 </div>
                 <div class="text comment-content" data-id="{{commentId}}">
                     {{#if isMarkdown}}
-                        {{#markdown}}
-                            {{content}}
-                        {{/markdown}}
+                        {{#markdown}}{{content}}{{/markdown}}
                     {{else}}
                         {{content}}
                     {{/if}}
@@ -132,9 +130,7 @@
                 <div class="content">
                     <p class="comment-content" data-id="{{commentId}}">
                         {{#if isMarkdown}}
-                            {{#markdown}}
-                                {{content}}
-                            {{/markdown}}
+                            {{#markdown}}{{content}}{{/markdown}}
                         {{else}}
                             {{content}}
                         {{/if}}
@@ -193,9 +189,7 @@
             <div class="item item-body comment">
                 <p class="comment-content" data-id="{{commentId}}">
                     {{#if isMarkdown}}
-                        {{#markdown}}
-                            {{content}}
-                        {{/markdown}}
+                        {{#markdown}}{{content}}{{/markdown}}
                     {{else}}
                         {{content}}
                     {{/if}}


### PR DESCRIPTION
This removes the whitespace inside the `{{#markdown}}` tag.

I guess it'll require a version bump on atmosphere.

fixes #48